### PR TITLE
Add some quality of life hooks

### DIFF
--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { Transaction } from "@gnosis.pm/safe-apps-sdk";
 import { Button, Loader, Text, Title } from "@gnosis.pm/safe-react-components";
-import { useSafeApp } from "./SafeAppProvider";
+import { useSafeInfo, useSendTransactions } from "./SafeAppProvider";
 
 const Container = styled.form`
   margin-bottom: 2rem;
@@ -16,7 +16,8 @@ const Container = styled.form`
 `;
 
 const App: React.FC = () => {
-  const { appsSdk, safeInfo } = useSafeApp();
+  const safeInfo = useSafeInfo();
+  const sendTransactions = useSendTransactions()
 
   const handleClick = () => {
     // just an example, this is not a valid transaction
@@ -28,7 +29,7 @@ const App: React.FC = () => {
       } as Transaction,
     ];
 
-    appsSdk?.sendTransactions(txs);
+    sendTransactions(txs);
   };
 
   if (!safeInfo) {

--- a/template/src/SafeAppProvider.tsx
+++ b/template/src/SafeAppProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useContext, useEffect } from "react";
-import initSdk, { SdkInstance, SafeInfo } from "@gnosis.pm/safe-apps-sdk";
+import initSdk, { Networks, RequestId, SdkInstance, SDK_MESSAGES, SafeInfo, SentSDKMessage, Transaction } from "@gnosis.pm/safe-apps-sdk";
 
 interface State {
   appsSdk: SdkInstance | undefined;
@@ -33,6 +33,31 @@ const SafeAppProvider: React.FC = ({ children }) => {
       {children}
     </stateCtx.Provider>
   );
+};
+
+export const useSafeInfo = (): SafeInfo | undefined => {
+  const { safeInfo } = useSafeApp();
+  return safeInfo;
+};
+
+export const useAppsSdk = (): SdkInstance => {
+  const { appsSdk } = useSafeApp();
+  return appsSdk;
+};
+
+export const useSafeAddress = (): string | undefined => {
+  const { safeAddress } = useSafeInfo() || {};
+  return safeAddress;
+};
+
+export const useSafeNetwork = (): Networks | undefined => {
+  const { network } = useSafeInfo() || {};
+  return network;
+};
+
+export const useSendTransactions = (): ((txs: Transaction[], requestId?: RequestId) => SentSDKMessage<SDK_MESSAGES.SEND_TRANSACTIONS>) => {
+  const { sendTransactions } = useAppsSdk();
+  return sendTransactions;
 };
 
 export default SafeAppProvider;

--- a/template/src/SafeAppProvider.tsx
+++ b/template/src/SafeAppProvider.tsx
@@ -55,7 +55,10 @@ export const useSafeNetwork = (): Networks | undefined => {
   return network;
 };
 
-export const useSendTransactions = (): ((txs: Transaction[], requestId?: RequestId) => SentSDKMessage<SDK_MESSAGES.SEND_TRANSACTIONS>) => {
+export const useSendTransactions = (): ((
+  txs: Transaction[],
+  requestId?: RequestId,
+) => SentSDKMessage<"SEND_TRANSACTIONS">) => {
   const { sendTransactions } = useAppsSdk();
   return sendTransactions;
 };


### PR DESCRIPTION
I've added a couple of hooks which I've found useful while making my Safe Apps. They allow direct access to the most used variables such as the safe's address and the function to send transactions.

I'll need to double check the types I've updated some of them for the new SDK version plus you're initialising the SDK slightly differently to how I do which means its "technically" possible for `appsSdk` to be undefined.